### PR TITLE
allow configuration of payment method label

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ SHOPIFY_API_KEY=your_client_id
 SHOPIFY_API_SECRET=your_client_secret
 DOMAIN=YOUR_HOSTED_APP_URL.COM
 LETSENCRYPT_EMAIL=johndoe@example.com
+PAYMENT_METHOD_LABEL="Pay with Bitcoin/Lightning"

--- a/extensions/btcpaycheckout/config.js
+++ b/extensions/btcpaycheckout/config.js
@@ -1,3 +1,4 @@
 export const config = {
-    appUrl: process.env.DOMAIN
+    appUrl: process.env.DOMAIN,
+    paymentMethodLabel: process.env.PAYMENT_METHOD_LABEL
   };

--- a/extensions/btcpaycheckout/src/Checkout.jsx
+++ b/extensions/btcpaycheckout/src/Checkout.jsx
@@ -38,10 +38,12 @@ function Extension() {
   const [isTokenValid, setIsTokenValid] = useState(false);
   const [isPaid, setIsPaid] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
-  const [modalTitle, setModalTitle] = useState('Pay with Bitcoin/Lightning Network');
   const shopName = shop.myshopifyDomain.split('.myshopify.com')[0];
   const options = useSelectedPaymentOptions();
-  let { appUrl } = config;
+  let { appUrl, paymentMethodLabel } = config;
+  const defaultPaymentMethodLabel = paymentMethodLabel || "Pay with Bitcoin/Lightning Network";
+  const [modalTitle, setModalTitle] = useState(defaultPaymentMethodLabel);
+
 
   useEffect(() => {
     const hasManualPaymentOption = options.some((option) => option.type.toLowerCase() === 'manualpayment');
@@ -98,7 +100,6 @@ function Extension() {
         else{
           setIsTokenValid(true);
           setOrderId(validationResponse.data.orderId);
-          setModalTitle(validationResponse.data.paymentMethodDescription);
           setRetryCount(0);
         }
       } else {


### PR DESCRIPTION
Resolves #2 

Allow users include an extra environment variable for payment method label..

IN scenarios where the label is missing, the default label is used