### PR TITLE
Display custom BTCPay payment for only manual/custom payment

### DIFF
--- a/extensions/btcpaycheckout/shopify.extension.toml
+++ b/extensions/btcpaycheckout/shopify.extension.toml
@@ -27,7 +27,7 @@ api_access = false
 # Gives your extension access to make external network calls, using the
 # JavaScript `fetch()` API. Learn more:
 # https://shopify.dev/docs/api/checkout-ui-extensions/unstable/configuration#network-access
-network_access = false
+network_access = true
 
 # Loads metafields on checkout resources, including the cart,
 # products, customers, and more. Learn more:

--- a/extensions/btcpaycheckout/shopify.extension.toml
+++ b/extensions/btcpaycheckout/shopify.extension.toml
@@ -27,7 +27,7 @@ api_access = false
 # Gives your extension access to make external network calls, using the
 # JavaScript `fetch()` API. Learn more:
 # https://shopify.dev/docs/api/checkout-ui-extensions/unstable/configuration#network-access
-network_access = true
+network_access = false
 
 # Loads metafields on checkout resources, including the cart,
 # products, customers, and more. Learn more:

--- a/extensions/btcpaycheckout/src/Checkout.jsx
+++ b/extensions/btcpaycheckout/src/Checkout.jsx
@@ -3,8 +3,10 @@ import {
   BlockStack,
   Button,
   Text,
-  useApi
+  useApi,
+  useSelectedPaymentOptions
 } from "@shopify/ui-extensions-react/checkout";
+import { useEffect, useState } from "react";
 
 // 1. Choose an extension target
 export default reactExtension(
@@ -13,16 +15,28 @@ export default reactExtension(
 );
 
 function Extension() {
+  const options = useSelectedPaymentOptions();
   const { shop, checkoutToken } = useApi();
+  const [hasManualPayment, setHasManualPayment] = useState(false);
+
+  
+  useEffect(() => { 
+    const hasManualPaymentOption = options.some((option) => option.type.toLowerCase() === 'manualpayment');
+    setHasManualPayment(hasManualPaymentOption);
+  }, [options]);
+
   const appUrl = `PLUGIN_URL/checkout?checkout_token=${checkoutToken.current}`;
+
+  if (!hasManualPayment) {
+    return null;
+  }
+
   return (
-    <>
-        <BlockStack>
-          <Text>Shop name: {shop.name}</Text>
-          <Text size="large" alignment="center" bold>Review and pay using BTCPay Server!</Text>
-          <Text>Please review your order and complete the payment using BTCPay Server.</Text>
-          <Button to={appUrl} external>Complete Payment</Button>
-        </BlockStack>
-    </>
+    <BlockStack>
+      <Text>Shop name: {shop.name}</Text>
+      <Text size="large" alignment="center" bold>Review and pay using BTCPay Server!</Text>
+      <Text>Please review your order and complete the payment using BTCPay Server.</Text>
+      <Button to={appUrl} external>Complete Payment</Button>
+    </BlockStack>
   );
 }

--- a/extensions/btcpaycheckout/src/Checkout.jsx
+++ b/extensions/btcpaycheckout/src/Checkout.jsx
@@ -6,7 +6,6 @@ import {
   useApi,
   useSelectedPaymentOptions
 } from "@shopify/ui-extensions-react/checkout";
-import { useState } from "react";
 
 // 1. Choose an extension target
 export default reactExtension(
@@ -17,52 +16,17 @@ export default reactExtension(
 function Extension() {
   const options = useSelectedPaymentOptions();
   const { shop, checkoutToken } = useApi();
-  const [isInvoiceSettled, setIsInvoiceSettled] = useState(false);
-  const [isCheckingPayment, setIsCheckingPayment] = useState(false);
   const hasManualPayment = options.some((option) => option.type.toLowerCase() === 'manualpayment');
-
   const appUrl = `PLUGIN_URL/checkout?checkout_token=${checkoutToken.current}`;
-  const validatePaymentUrl = `PLUGIN_URL/validate-payment?checkout_token=${checkoutToken.current}`;
-
-  const checkPaymentStatus = async () => {
-    try {
-      const response = await fetch(validatePaymentUrl);
-      if (!response.ok) return;
-
-      const data = await response.json();
-      if (data.IsInvoiceSettled) {
-        setIsInvoiceSettled(true);
-        setIsCheckingPayment(false);
-      }
-    } catch (error) {}
-  };
-
-
-  const startCheckingPayment = () => {
-    if (isCheckingPayment) return;
-
-    setIsCheckingPayment(true);
-    const interval = setInterval(async () => {
-      await checkPaymentStatus();
-    }, 4000);
-    return () => clearInterval(interval);
-  };
-
 
   if (!hasManualPayment) return null;
 
   return (
     <BlockStack>
       <Text>Shop name: {shop.name}</Text>
-      {isInvoiceSettled ? (
-        <Text size="large" alignment="center" bold>Payment received. Thank you for your order!</Text>
-      ) : (
-        <>
-          <Text size="large" alignment="center" bold>Review and pay using BTCPay Server!</Text>
-          <Text>Please review your order and complete the payment using BTCPay Server.</Text>
-          <Button to={appUrl} external onPress={startCheckingPayment}>Complete Payment</Button>
-        </>
-      )}
+      <Text size="large" alignment="center" bold>Review and pay using BTCPay Server!</Text>
+      <Text>Please review your order and complete the payment using BTCPay Server.</Text>
+      <Button to={appUrl} external>Complete Payment</Button>
     </BlockStack>
   );
 }

--- a/extensions/btcpaycheckout/src/Checkout.jsx
+++ b/extensions/btcpaycheckout/src/Checkout.jsx
@@ -6,7 +6,7 @@ import {
   useApi,
   useSelectedPaymentOptions
 } from "@shopify/ui-extensions-react/checkout";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 // 1. Choose an extension target
 export default reactExtension(
@@ -17,26 +17,52 @@ export default reactExtension(
 function Extension() {
   const options = useSelectedPaymentOptions();
   const { shop, checkoutToken } = useApi();
-  const [hasManualPayment, setHasManualPayment] = useState(false);
-
-  
-  useEffect(() => { 
-    const hasManualPaymentOption = options.some((option) => option.type.toLowerCase() === 'manualpayment');
-    setHasManualPayment(hasManualPaymentOption);
-  }, [options]);
+  const [isInvoiceSettled, setIsInvoiceSettled] = useState(false);
+  const [isCheckingPayment, setIsCheckingPayment] = useState(false);
+  const hasManualPayment = options.some((option) => option.type.toLowerCase() === 'manualpayment');
 
   const appUrl = `PLUGIN_URL/checkout?checkout_token=${checkoutToken.current}`;
+  const validatePaymentUrl = `PLUGIN_URL/validate-payment?checkout_token=${checkoutToken.current}`;
 
-  if (!hasManualPayment) {
-    return null;
-  }
+  const checkPaymentStatus = async () => {
+    try {
+      const response = await fetch(validatePaymentUrl);
+      if (!response.ok) return;
+
+      const data = await response.json();
+      if (data.IsInvoiceSettled) {
+        setIsInvoiceSettled(true);
+        setIsCheckingPayment(false);
+      }
+    } catch (error) {}
+  };
+
+
+  const startCheckingPayment = () => {
+    if (isCheckingPayment) return;
+
+    setIsCheckingPayment(true);
+    const interval = setInterval(async () => {
+      await checkPaymentStatus();
+    }, 4000);
+    return () => clearInterval(interval);
+  };
+
+
+  if (!hasManualPayment) return null;
 
   return (
     <BlockStack>
       <Text>Shop name: {shop.name}</Text>
-      <Text size="large" alignment="center" bold>Review and pay using BTCPay Server!</Text>
-      <Text>Please review your order and complete the payment using BTCPay Server.</Text>
-      <Button to={appUrl} external>Complete Payment</Button>
+      {isInvoiceSettled ? (
+        <Text size="large" alignment="center" bold>Payment received. Thank you for your order!</Text>
+      ) : (
+        <>
+          <Text size="large" alignment="center" bold>Review and pay using BTCPay Server!</Text>
+          <Text>Please review your order and complete the payment using BTCPay Server.</Text>
+          <Button to={appUrl} external onPress={startCheckingPayment}>Complete Payment</Button>
+        </>
+      )}
     </BlockStack>
   );
 }


### PR DESCRIPTION
This PR improves UX experiences such that payment with BTCPay Server would only be displayed on the thank you page where manual payment was selected in checkout
