### PR TITLE
Bump app to 3.92.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:18-alpine3.20
+FROM node:20-alpine3.20
 
 # Install xdg-utils (BTCPay Server mod)
 RUN apk add --no-cache bash xdg-utils git
 # Install Shopify CLI globally (BTCPay Server mod)
-RUN npm install -g @shopify/cli@3.84.1
+RUN npm install -g @shopify/cli@3.92.1
 
 EXPOSE 3000
 


### PR DESCRIPTION
Shopify app deploy fails with “At least one specification (.toml OR .json) file is required” on CLI 3.84.2

https://community.shopify.dev/t/shopify-app-deploy-fails-with-at-least-one-specification-toml-or-json-file-is-required-on-cli-3-84-2/32421