### PR TITLE
Bumping shopify app to 2026-04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM node:20-alpine3.20
+FROM node:22-alpine3.20
 
 # Install xdg-utils (BTCPay Server mod)
 RUN apk add --no-cache bash xdg-utils git
 # Install Shopify CLI globally (BTCPay Server mod)
-RUN npm install -g @shopify/cli@3.92.1
+RUN npm install -g @shopify/cli@4.4.0
+RUN shopify config autoupgrade off
 
 EXPOSE 3000
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -16,7 +16,7 @@ sed -i "s|PLUGIN_URL|${PLUGIN_URL}|g" shopify.app.toml
 sed -i "s|PLUGIN_URL|${PLUGIN_URL}|g" extensions/btcpaycheckout/src/Checkout.jsx
 echo "Settings saved"
 
-if shopify app deploy -f --no-color; then
+if shopify app deploy --allow-updates --no-color; then
 echo "SUCCESS=true"
 else
 echo "SUCCESS=false"

--- a/extensions/btcpaycheckout/package.json
+++ b/extensions/btcpaycheckout/package.json
@@ -4,12 +4,8 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "dependencies": {
-    "react": "^18.0.0",
-    "@shopify/ui-extensions": "2024.10.x",
-    "@shopify/ui-extensions-react": "2024.10.x"
-  },
-  "devDependencies": {
-    "@types/react": "^18.0.0",
-    "react-reconciler": "0.29.0"
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "2026.4.x"
   }
 }

--- a/extensions/btcpaycheckout/shopify.extension.toml
+++ b/extensions/btcpaycheckout/shopify.extension.toml
@@ -3,7 +3,7 @@
 
 # The version of APIs your extension will receive. Learn more:
 # https://shopify.dev/docs/api/usage/versioning
-api_version = "2025-07"
+api_version = "2026-04"
 
 [[extensions]]
 name = "BTCPay Checkout"

--- a/extensions/btcpaycheckout/src/Checkout.jsx
+++ b/extensions/btcpaycheckout/src/Checkout.jsx
@@ -1,74 +1,84 @@
-import {
-  reactExtension,
-  BlockStack,
-  Button,
-  Text,
-  useApi,
-  Spinner,
-  useTranslate,
-  useSelectedPaymentOptions
-} from "@shopify/ui-extensions-react/checkout";
-import { useEffect, useState } from "react";
+import '@shopify/ui-extensions/preact';
+import { render } from 'preact';
+import { useEffect, useState } from 'preact/hooks';
 
-// 1. Choose an extension target
-export default reactExtension(
-  'purchase.thank-you.block.render',
-  () => <Extension />,
-);
+export default function extension() {
+  render(<Extension />, document.body);
+}
 
 function Extension() {
-  const translate = useTranslate();
-  const options = useSelectedPaymentOptions();
-  const { shop, checkoutToken } = useApi();
+  const shop = shopify.shop;
+  const checkoutToken = shopify.checkoutToken.value;
+  const options = shopify.selectedPaymentOptions.value;
+  const translate = shopify.i18n.translate;
+  const hasManualPayment = options.some((option) => option.type.toLowerCase() === 'manualpayment');
+
   const [isLoading, setIsLoading] = useState(true);
   const [isSuccess, setIsSuccess] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
-  const hasManualPayment = options.some((option) => option.type.toLowerCase() === 'manualpayment');
-  const appUrl = `PLUGIN_URL/checkout?checkout_token=${checkoutToken.current}`;
 
   useEffect(() => {
-    if (!hasManualPayment) return;
-    const fetchInvoice = async () => {
+    if (!hasManualPayment || !checkoutToken) return;
+
+    let cancelled = false;
+    const appUrl = `PLUGIN_URL/checkout?checkout_token=${checkoutToken}`;
+    const MAX_ATTEMPTS = 3;
+
+    const fetchInvoice = async (attempt = 0) => {
       setIsLoading(true);
       try {
         const response = await fetch(`${appUrl}&redirect=false`, {
           method: 'GET',
           headers: { 'Content-Type': 'application/json' },
         });
+        if (cancelled) return;
+
         if (response.ok) {
           setIsSuccess(true);
-        }
-        else if (response.status !== 404) {
+          setIsLoading(false);
+        } else if (response.status === 404 && attempt < MAX_ATTEMPTS) {
+          setTimeout(() => fetchInvoice(attempt + 1), 1000 * (attempt + 1));
+          return;
+        } else if (response.status !== 404) {
           const errorText = await response.text();
           setErrorMessage(translate("error.fetch_invoice", { error: errorText || response.statusText }));
+          setIsLoading(false);
+        } else {
+          setErrorMessage(translate("error.fetch_invoice", { error: 'Order not found after retries' }));
+          setIsLoading(false);
         }
       } catch (error) {
-        setErrorMessage(translate("error.general", { error: error.message }));
-      }
-      finally {
-        setIsLoading(false);
+        if (!cancelled) {
+          setErrorMessage(translate('error.general', { error: error.message }));
+          setIsLoading(false);
+        }
       }
     };
-    const timer = setTimeout(fetchInvoice, 1000);
-    return () => clearTimeout(timer)
-  }, [hasManualPayment]);
+
+    fetchInvoice();
+    return () => { cancelled = true; };
+  }, [hasManualPayment, checkoutToken]);
 
   if (!hasManualPayment) return null;
 
   return (
-    <BlockStack>
-      {isLoading && <Spinner />}
-      {!isLoading && errorMessage && (
-        <Text size="large" appearance="critical">{errorMessage}</Text>
-      )}
-      {!isLoading && isSuccess && (
-        <>
-          <Text>{translate("shop_name")}: {shop.name}</Text>
-          <Text size="large" alignment="center" bold>{translate("reviewAndPay")}</Text>
-          <Text>{translate("reviewOrderMessage")}.</Text>
-          <Button to={appUrl} external>{translate("complete_payment")}</Button>
-        </>
-      )}
-    </BlockStack>
+    <s-box padding="base" border="base" borderRadius="base">
+      <s-stack direction="block" gap="base">
+        {isLoading && <s-spinner />}
+        {!isLoading && errorMessage && (
+          <s-text tone="critical" type="strong">{errorMessage}</s-text>
+        )}
+        {!isLoading && isSuccess && (
+          <>
+            <s-text>{translate('shop_name')}: {shop.name}</s-text>
+            <s-text type="strong">{translate('reviewAndPay')}</s-text>
+            <s-text>{translate('reviewOrderMessage')}.</s-text>
+            <s-button href={`PLUGIN_URL/checkout?checkout_token=${checkoutToken}`} target="_blank" variant="primary">
+              {translate('complete_payment')}
+            </s-button>
+          </>
+        )}
+      </s-stack>
+    </s-box>
   );
 }

--- a/extensions/btcpaycheckout/src/Checkout.jsx
+++ b/extensions/btcpaycheckout/src/Checkout.jsx
@@ -22,9 +22,9 @@ function Extension() {
 
     let cancelled = false;
     const appUrl = `PLUGIN_URL/checkout?checkout_token=${checkoutToken}`;
-    const MAX_ATTEMPTS = 3;
 
-    const fetchInvoice = async (attempt = 0) => {
+    const fetchInvoice = async () => {
+      if (cancelled) return;
       setIsLoading(true);
       try {
         const response = await fetch(`${appUrl}&redirect=false`, {
@@ -36,17 +36,11 @@ function Extension() {
         if (response.ok) {
           setIsSuccess(true);
           setIsLoading(false);
-        } else if (response.status === 404 && attempt < MAX_ATTEMPTS) {
-          setTimeout(() => fetchInvoice(attempt + 1), 1000 * (attempt + 1));
           return;
-        } else if (response.status !== 404) {
-          const errorText = await response.text();
-          setErrorMessage(translate("error.fetch_invoice", { error: errorText || response.statusText }));
-          setIsLoading(false);
-        } else {
-          setErrorMessage(translate("error.fetch_invoice", { error: 'Order not found after retries' }));
-          setIsLoading(false);
         }
+        const errorText = await response.text();
+        setErrorMessage(translate('error.fetch_invoice', { error: errorText || response.statusText }));
+        setIsLoading(false);
       } catch (error) {
         if (!cancelled) {
           setErrorMessage(translate('error.general', { error: error.message }));
@@ -55,8 +49,11 @@ function Extension() {
       }
     };
 
-    fetchInvoice();
-    return () => { cancelled = true; };
+    const initialDelay = setTimeout(fetchInvoice, 2000);
+    return () => { 
+      cancelled = true;
+      clearTimeout(initialDelay);
+    };
   }, [hasManualPayment, checkoutToken]);
 
   if (!hasManualPayment) return null;

--- a/extensions/btcpaycheckout/tsconfig.json
+++ b/extensions/btcpaycheckout/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true
+  },
+  "include": [
+    "./src",
+    "./shopify.d.ts"
+  ]
+}

--- a/shopify.app.toml.example
+++ b/shopify.app.toml.example
@@ -14,5 +14,5 @@ scopes = "read_orders,write_orders,read_customers"
 redirect_urls = ["PLUGIN_URL/checkout"]
 
 [webhooks]
-api_version = "2025-07"
+api_version = "2026-04"
 


### PR DESCRIPTION
First we currently run shopify version 2025-07 which would reach EOL soon and is the last version supporting React, so this PR bumps the Shopify checkout extension to API 2026-04

<img width="870" height="245" alt="image" src="https://github.com/user-attachments/assets/9848e532-657f-4692-8b8e-019d10477318" />


Also fixes an intermittent "Invalid checkout token" error some users hit at checkout

